### PR TITLE
Allow users to rebind the mapping, and better filetype detection

### DIFF
--- a/plugin/howdoi.vim
+++ b/plugin/howdoi.vim
@@ -52,9 +52,11 @@ query = vim.current.line
 filetype = vim.eval("&ft")
 
 # add filetype to query if not already present
-if filetype in filetypes:
-  if filetype not in query:
+if "vim" not in query and filetype not in query:
+  if filetype in filetypes:
     query += " in " + filetypes[filetype]
+  else:
+    query += " in " + filetype
 
 # Call howdoi, I'm way too lazy
 p = subprocess.Popen("howdoi " + query,
@@ -94,7 +96,7 @@ function! s:CreateMaps(target, desc, combo)
   " Setup default combo
   if strlen(a:combo) && !exists("no_plugin_maps")
     if !hasmapto(plug)
-      execute 'map ' . a:combo . ' ' . plug
+      execute 'nnoremap ' . a:combo . ' ' . plug
     endif
   endif
 

--- a/plugin/howdoi.vim
+++ b/plugin/howdoi.vim
@@ -96,7 +96,7 @@ function! s:CreateMaps(target, desc, combo)
   " Setup default combo
   if strlen(a:combo) && !exists("no_plugin_maps")
     if !hasmapto(plug)
-      execute 'nnoremap ' . a:combo . ' ' . plug
+      execute 'map ' . a:combo . ' ' . plug
     endif
   endif
 

--- a/plugin/howdoi.vim
+++ b/plugin/howdoi.vim
@@ -15,12 +15,14 @@ if exists("g:howdoi")
     finish
 endif
 
+if !exists('g:howdoi_map') | let g:howdoi_map = '<c-h>' | en
+
 if !has('python')
   echoerr "Required vim compiled with +python"
     finish
 endif
 
-let g:howdoi = 1 
+let g:howdoi = 1
 
 " Section: Functions definitions {{{1
 " ===========================================================================
@@ -36,7 +38,7 @@ if howdoi_installed == "0":
   print "Expected howdoi package to be installed"
 
 filetypes = {
-  "c" : "c", 
+  "c" : "c",
   "java" : "java",
   "cpp" : "c++",
   "cs" : "c#",
@@ -44,7 +46,7 @@ filetypes = {
   "php" : "php",
   "javascript" : "javascript",
   "ruby" : "ruby"
-} 
+}
 
 query = vim.current.line
 filetype = vim.eval("&ft")
@@ -109,5 +111,5 @@ function! s:CreateMaps(target, desc, combo)
 endfunction
 
 " Function name / Menu entry / Default mapping
-call s:CreateMaps('Howdoi',        'howdoi',         '<C-h>')
+call s:CreateMaps('Howdoi', 'howdoi', g:howdoi_map)
 


### PR DESCRIPTION
We can now set `g:howdoi_map` to change the default mapping.

Additionally, howdoi will now insert the filetype even for unknown filetypes. This lets us use the `filetypes` array for filetypes whose vim representation isn't the same as their common name, instead of being a canonical list of things you can search for. For bonus points, it will also let you use 'vim' as a filetype if you want editor advice.
