### PR TITLE
Do not use shell=True option for subprocess

### DIFF
--- a/plugin/howdoi.vim
+++ b/plugin/howdoi.vim
@@ -55,10 +55,9 @@ if filetype in filetypes:
     query += " in " + filetypes[filetype]
 
 # Call howdoi, I'm way too lazy
-p = subprocess.Popen("howdoi " + query,
+p = subprocess.Popen(["howdoi", query],
   stdout=subprocess.PIPE,
-  stderr=subprocess.PIPE,
-  shell=True)
+  stderr=subprocess.PIPE)
 output, errors = p.communicate()
 
 # Clean up a bit


### PR DESCRIPTION
The use of `shell=True` in subprocess is highly discouraged and can have unexpected (in the best of the scenarios) or even disastrous consequences.

When using `shell=True` in fact, the string is directly passed to the shell, so what happens when you use operators such as: `;`, `!`, `>`, `>>`, `<`, `<<`, `&`, `&&`, `|`, `||` ?

These are directly processed by the shell, and since these are common symbols in a programming language it may lead to really bad consequences. For example try to use this:

    open a file in php | wc -l

The output is `11`, because there are 11 lines in the `howdoi` output.

    use the operator > in c

This will create a file `in` since `>` redirects the output of `howdoi use the operator` to the fine `in`.

This can lead to really bad consequences. I hope nobody ever looked for how to use `|` to `rm -rf`..

`subprocess.Popen` takes a list of strings as input (the `argv`), so you just need to remove `shell=True` and use `['howdoi', query]` as argument and you are on the safe side!